### PR TITLE
Avoid raising an exception when export spans if exceeding buffer size

### DIFF
--- a/lib/opencensus/trace/exporters/datadog.rb
+++ b/lib/opencensus/trace/exporters/datadog.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'opencensus'
 
 require 'opencensus/trace/exporters/datadog/transport'
 require 'opencensus/trace/exporters/datadog/worker'

--- a/lib/opencensus/trace/exporters/datadog.rb
+++ b/lib/opencensus/trace/exporters/datadog.rb
@@ -13,8 +13,8 @@ module OpenCensus
 
         def self.log
           unless defined? @logger
-            @logger = Logger.new(STDOUT)
-            @logger.level = Logger::WARN
+            @logger = ::Logger.new(STDOUT)
+            @logger.level = ::Logger::WARN
           end
           @logger
         end

--- a/lib/opencensus/trace/exporters/datadog/converter.rb
+++ b/lib/opencensus/trace/exporters/datadog/converter.rb
@@ -1,4 +1,3 @@
-require 'opencensus'
 require 'ddtrace/ext/distributed'
 require 'ddtrace/ext/priority'
 require 'ddtrace/ext/errors'

--- a/spec/opencensus/datadog_spec.rb
+++ b/spec/opencensus/datadog_spec.rb
@@ -1,9 +1,5 @@
 RSpec.describe Opencensus::Datadog do
   it "has a version number" do
-    expect(Opencensus::Datadog::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
+    expect(OpenCensus::Datadog::VERSION).not_to be nil
   end
 end

--- a/spec/opencensus/trace/exporters/datadog_spec.rb
+++ b/spec/opencensus/trace/exporters/datadog_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe OpenCensus::Trace::Exporters::Datadog do
+  describe '.log' do
+    it 'uses default logger' do
+      expect(OpenCensus::Trace::Exporters::Datadog.log.level).to eq ::Logger::WARN
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.expose_dsl_globally = true
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
Current implementation causes `NoMethodError` exception when export when try to add some spans if exceeding buffer size.

I fixed this bug and added a spec.