### PR TITLE
Add version constraint (ddtrace < 1.0) to avoid incompatibility

### DIFF
--- a/opencensus-datadog.gemspec
+++ b/opencensus-datadog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'msgpack'
   spec.add_dependency 'opencensus'
-  spec.add_dependency 'ddtrace'
+  spec.add_dependency 'ddtrace', '< 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This PR adds a temporal version constraint (`ddtrace < 1.0`) to avoid incompatibility of [ddtrace 1.0](https://github.com/DataDog/dd-trace-rb/releases/tag/v1.0.0) until this gem supports ddtrace 1.0.

Datadog has recently released [ddtrace 1.0](https://github.com/DataDog/dd-trace-rb/releases/tag/v1.0.0).
ddtrace 1.0 has some incompatibility with 0.x (Ref: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.0.0), so some fixes to this gem are needed to support 1.0.


