### PR TITLE
Update development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 3.1
+  - 3.0
+  - 2.7
 before_install: gem install bundler -v 1.16.2
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
   - 3.1
   - 3.0
   - 2.7
-before_install: gem install bundler -v 1.16.2
+before_install: gem install bundler -v "< 3"
 script:
   - bundle exec rspec

--- a/opencensus-datadog.gemspec
+++ b/opencensus-datadog.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ddtrace'
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/opencensus-datadog.gemspec
+++ b/opencensus-datadog.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opencensus'
   spec.add_dependency 'ddtrace'
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This PR updates outdated development dependencies.

* Ruby: Use maintained versions (3.1, 3.0, 2.7) (Ref: https://www.ruby-lang.org/en/downloads/branches/)
* Bundler: Use 2.x to use latest versions (Ref: https://rubygems.org/gems/bundler/versions)
* Rake: Use 13.x to use latest versions (Ref: https://rubygems.org/gems/rake/versions)