### PR TITLE
Bump gem version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This library is the implementation of [OpenCensus](https://github.com/census-instrumentation/opencensus-ruby) exporter that transfer metrics to [Datadog APM](https://www.datadoghq.com/apm/).
 It is depending on Datadog Agent v6.
 
+## Requirements
+
+- Ruby >= 3.2
+- `datadog` gem v2.x
+
 ## Installation
 
 Add `opencensus-datadog` to your application's Gemfile:

--- a/lib/opencensus/datadog/version.rb
+++ b/lib/opencensus/datadog/version.rb
@@ -1,5 +1,5 @@
 module OpenCensus
   module Datadog
-    VERSION = "1.0.0"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
## Why

The migration from `ddtrace` v1 to `datadog` v2 (#15) and the Ruby 3.2+ support update are complete. Bump the gem major version to 2.0.0 to reflect these breaking changes.

## What

- Bump gem version from 1.0.0 to 2.0.0
- Add Requirements section to README (Ruby >= 3.2, `datadog` gem v2.x)